### PR TITLE
Bump `spatie/laravel-package-tools` version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.0",
         "filament/filament": "^2.0",
-        "spatie/laravel-package-tools": "^1.9.2",
+        "spatie/laravel-package-tools": "^1.13.5",
         "illuminate/contracts": "^9.0"
     },
     "require-dev": {


### PR DESCRIPTION
Allows to use the new install command, without failing the tests on `prefer-lowest` stability